### PR TITLE
Create Backlog type

### DIFF
--- a/haskell-version/app/Main.hs
+++ b/haskell-version/app/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import qualified Data.Map as Map
 import Data.Map (Map)
 
-import MonteCarlo (Backlog, Size(..), Statistics(..), run)
+import MonteCarlo (Backlog(..), Size(..), Statistics(..), run)
 
 iterations :: Int
 iterations = 1000
@@ -12,21 +12,21 @@ percentiles :: [Int]
 percentiles = [50, 80, 90, 95]
 
 backlog :: Backlog
-backlog =
-    [ Small
-    , Medium
-    , Small
-    , Small
-    , Small
-    , Small
-    ]
-
-pastPerfomance :: Map Size Statistics
-pastPerfomance =
-    Map.fromList
-        [ (Small, Statistics {low = 1.2, mode = 2.0, high = 3.0})
-        , (Medium, Statistics {low = 1.0, mode = 12.0, high = 24.0})
+backlog = Backlog
+    { stories =
+        [ Small
+        , Medium
+        , Small
+        , Small
+        , Small
+        , Small
         ]
+    , statistics = 
+        Map.fromList
+            [ (Small, Statistics {low = 1.2, mode = 2.0, high = 3.0})
+            , (Medium, Statistics {low = 1.0, mode = 12.0, high = 24.0})
+            ]
+    }
 
 main :: IO ()
-main = run iterations percentiles backlog pastPerfomance >>= print
+main = run iterations percentiles backlog >>= print


### PR DESCRIPTION
Some post-workshop refactoring

Several functions had both `[Size]` and `Map Size Statistics` passed as arguments so it seemed sensible to create a type to combine them.