### PR TITLE
Refactor add monad random

### DIFF
--- a/haskell-version/haskell-monte-carlo.cabal
+++ b/haskell-version/haskell-monte-carlo.cabal
@@ -31,10 +31,10 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.7 && <5
+      MonadRandom
+    , base >=4.7 && <5
     , containers
     , random
-    , random-fu
   default-language: Haskell2010
 
 executable haskell-monte-carlo-exe
@@ -45,11 +45,11 @@ executable haskell-monte-carlo-exe
       app
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      MonadRandom
+    , base >=4.7 && <5
     , containers
     , haskell-monte-carlo
     , random
-    , random-fu
   default-language: Haskell2010
 
 test-suite haskell-monte-carlo-test
@@ -62,11 +62,11 @@ test-suite haskell-monte-carlo-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      QuickCheck
+      MonadRandom
+    , QuickCheck
     , base >=4.7 && <5
     , containers
     , haskell-monte-carlo
     , hspec
     , random
-    , random-fu
   default-language: Haskell2010

--- a/haskell-version/package.yaml
+++ b/haskell-version/package.yaml
@@ -22,8 +22,8 @@ description:         Please see the README on GitHub at <https://github.com/gith
 dependencies:
 - base >= 4.7 && < 5
 - random
-- random-fu
 - containers
+- MonadRandom
 
 library:
   source-dirs: src


### PR DESCRIPTION
Post-workshop refactorings. This PR continues from #1 so merge that before reviewing this.

Rather than using `IO` the function now use `MonadRandom`. This means that these functions are no longer able to call `IO` functions (such as `print`) but they can use the random number functionality. This means that you could now run this without `IO` but would have to provide the generator.